### PR TITLE
BMM150 and MPU6886: fix DATA_NUM re-definition warning

### DIFF
--- a/src/openEL_SensorM5StackGrayBMM150.cpp
+++ b/src/openEL_SensorM5StackGrayBMM150.cpp
@@ -107,7 +107,7 @@ ReturnCode SensorM5StackGrayBMM150::fncGetValLst(HALComponent *pHALComponent, fl
     *(*valueList+4) = magRawY;
     *(*valueList+5) = magRawZ;
 
-    **num = DATA_NUM;
+    **num = BMM150_DATA_NUM;
 
     return HAL_OK;
 }
@@ -125,7 +125,7 @@ ReturnCode SensorM5StackGrayBMM150::fncGetTimedValLst(HALComponent *pHALComponen
     *(*valueList+5) = magRawZ;
 
     **timeValue = (unsigned int)millis();
-    **num = DATA_NUM;
+    **num = BMM150_DATA_NUM;
 
     return HAL_OK;
 }

--- a/src/openEL_SensorM5StackGrayBMM150.hpp
+++ b/src/openEL_SensorM5StackGrayBMM150.hpp
@@ -157,7 +157,7 @@
 
 #define BMM150_GET_BITS_POS_0(reg_data, bitname)  (reg_data & (bitname##_MSK))
 
-#define DATA_NUM 6
+#define BMM150_DATA_NUM 6
 
 struct BMM150Setting {
     /*! Control measurement of XYZ axes */

--- a/src/openEL_SensorM5StackGrayMPU6886.cpp
+++ b/src/openEL_SensorM5StackGrayMPU6886.cpp
@@ -138,7 +138,7 @@ ReturnCode SensorM5StackGrayMPU6886::fncGetValLst(HALComponent *pHALComponent, f
         *(*valueList+(i*14)+12) = (int16_t)(imu_data[i].value.gyro_z_l | (imu_data[i].value.gyro_z_h << 8));
         *(*valueList+(i*14)+13) = (int16_t)(imu_data[i].value.temp_l | (imu_data[i].value.temp_h << 8));
     }
-    **num = data_number * DATA_NUM;
+    **num = data_number * MPU6886_DATA_NUM;
 
     return HAL_OK;
 }
@@ -173,7 +173,7 @@ ReturnCode SensorM5StackGrayMPU6886::fncGetTimedValLst(HALComponent *pHALCompone
         *(*valueList+(i*14)+13) = (int16_t)(imu_data[i].value.temp_l | (imu_data[i].value.temp_h << 8));
     }
     **timeValue = (unsigned int)millis();
-    **num = data_number * DATA_NUM;
+    **num = data_number * MPU6886_DATA_NUM;
 
     return HAL_OK;
 }

--- a/src/openEL_SensorM5StackGrayMPU6886.hpp
+++ b/src/openEL_SensorM5StackGrayMPU6886.hpp
@@ -78,7 +78,7 @@
 #define AtR     0.0174533
 #define Gyro_Gr 0.0010653
 
-#define DATA_NUM 14
+#define MPU6886_DATA_NUM 14
 
 typedef union {
     uint8_t raw[14];


### PR DESCRIPTION
Dear project members,

I followed the `Getting Started with OpenEL for Arduino` [1] guide
on an M5Stack Gray and noticed a compile warning regarding `DATA_NUM`:

        In file included from /home/ytsuchiya/Arduino/libraries/openel-arduino-3.2.1/src/openEL_registryConfig.cpp:38:
        /home/ytsuchiya/Arduino/libraries/openel-arduino-3.2.1/src/openEL_SensorM5StackGrayBMM150.hpp:160: warning: "DATA_NUM" redefined
         #define DATA_NUM 6

        In file included from /home/ytsuchiya/Arduino/libraries/openel-arduino-3.2.1/src/openEL_registryConfig.cpp:37:
        /home/ytsuchiya/Arduino/libraries/openel-arduino-3.2.1/src/openEL_SensorM5StackGrayMPU6886.hpp:81: note: this is the location of the previous definition
         #define DATA_NUM 14

This warning can be fixed by making the `DATA_NUM` unique to DeviceName.

The first patch makes the name unique to BMM150.
The second patch makes the name unique to MPU6886.

Compile tested then tested on M5Stack Gray and confirmed that it is
still working without breakage.


Sincerely,

Tsuchiya Yuto



References:
[1] https://openel.github.io/openel-arduino/